### PR TITLE
커뮤니티 게시글 상세내용 조회 API 응답 필드에서 유저의 좋아요, 신고 여부 필드를 추가한다.

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -578,8 +578,9 @@ paths:
                       post:
                         type: object
                         properties:
-                          user:
+                          createdUser:
                             type: object
+                            description: 게시글 작성자
                             properties:
                               id:
                                 type: integer
@@ -629,6 +630,21 @@ paths:
                             type: integer
                             description: 댓글 수
                             example: 39
+                          userActionHistory:
+                            type: object
+                            description: 게시글에 대한 유저의 이력
+                            properties:
+                              thumbsUpped:
+                                type: boolean
+                                description: 좋아요 여부
+                                example: true
+                              reported:
+                                type: boolean
+                                description: 신고 여부
+                                example: false
+                            required:
+                              - thumbsUpped
+                              - reported
                         required:
                           - user
                           - id
@@ -638,6 +654,7 @@ paths:
                           - create_date
                           - thumbsUpCount
                           - commentCount
+                          - userActionHistory
                     required:
                       - post
                 required:


### PR DESCRIPTION
`$.data.post.thumbsUpped` 또는 `$.data.post.reported` 필드로 추가를 할지 고민을 하다가 해당 게시글이 "좋아요된적이 있는지?" 또는 "신고된적이 있는지" 의미랑 혼동이 있을 수도 있다고 느껴져서 `$.data.post.userActionHistory.thumbsUpped`, `$.data.post.userActionHistory.reported` 필드로 추가해보았습니다. 
`$.data.post.userActionHistory` 필드에서 user는 현재 로그인 유저를 의미하지만 기존에 있던 `$.data.post.user` 필드는 게시글 작성자를 의미하여 같은 user가 서로 다른 의미를 지니고 있기 때문에 명확하게 차이를 두기 위해서 작성자를 의미하도록 `$.data.post.createdUser`로 필드명을 변경했습니다.

close #1