### PR TITLE
파일 업로드를 위한 서명 URL 생성 API 요청에서 이미지의 타입과 용량 제한을 설정한다.

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -164,26 +164,32 @@ paths:
                         type: string
                         description: |-
                           파일 업로드 유형
-                          - USER_PROFILE_IMAGE
+                          - PROFILE_IMAGE
                           - POST_IMAGE
                       fileContentLength:
                         type: integer
                         description: |-
                           Content-Length(bytes)
-                          - USER_PROFILE_IMAGE: 최대 ? bytes
-                          - POST_IMAGE: 최대 ? bytes
+                          - PROFILE_IMAGE: 최대 1048576 bytes(1mb)
+                          - POST_IMAGE: 최대 1048576 bytes(1mb)
                       fileContentType:
                         type: string
                         description: |-
                           Content-Type
-                          - USER_PROFILE_IMAGE: image/*
-                          - POST_IMAGE: image/*
+                          - PROFILE_IMAGE:
+                            - image/gif
+                            - image/png
+                            - image/jpeg
+                          - POST_IMAGE: 
+                            - image/gif
+                            - image/png
+                            - image/jpeg
                     required:
                       - fileUploadRequestType
                       - fileContentLength
                       - fileContentType
                   example:
-                    - fileUploadRequestType: USER_PROFILE_IMAGE
+                    - fileUploadRequestType: PROFILE_IMAGE
                       fileContentLength: 500000
                       fileContentType: image/png
                     - fileUploadRequestType: POST_IMAGE


### PR DESCRIPTION
파일 업로드를 위한 서명 URL 생성 요청에서 이미지의 타입과 용량 제한이 필요합니다.
용량 제한이 너무 적지는 않을지, 추가적으로 허용이 필요한 이미지 타입이 있을지 의견주시면 감사하겠습니다.

close #8