### PR TITLE
Oauth2 로그인 회원의 등록 여부 확인 API를 추가한다.

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -239,6 +239,48 @@ paths:
                 required:
                   - data
 
+  /api/v1/oauth2/{client}/users/registered:
+    get:
+      security:
+        - 3rdPartyBearerToken: []
+      tags:
+        - 유저
+      summary: Oauth 로그인 회원 등록 여부 확인
+      description: |-
+        Oauth 로그인 회원의 등록 여부를 확인합니다.
+      parameters:
+        - in: path
+          name: client
+          schema:
+            type: string
+            enum:
+              - kakao
+              - apple
+          required: true
+          description: |-
+            클라이언트
+              - kakao
+              - apple
+      responses:
+        200:
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      isRegistered:
+                        type: boolean
+                        description: 이미 등록되었는지 여부
+                        example: false
+                    required:
+                      - isRegistered
+                required:
+                  - data
+
   /api/v1/users/{userId}:
     patch:
       security:
@@ -1024,5 +1066,10 @@ components:
     bearerToken:
       type: http
       scheme: bearer
+      description: JWT 서명 토큰(access_token)
+    3rdPartyBearerToken:
+      type: http
+      scheme: bearer
+      description: 3rd-party JWT 서명 토큰(id_token)
 
 servers: [ ]


### PR DESCRIPTION
<img width="988" alt="image" src="https://github.com/team-ppeople/pp-oas-swagger/assets/52724515/c62a18b6-1030-4a34-899f-631bc5b0f593">

Oauth2 로그인 후 기존에 등록되지 않은 회원만 약관 동의 화면으로 이동시킬 수 있도록 Oauth2 로그인 회원의 등록 여부 확인 API를 추가합니다.
혹시 응답으로 필요한 데이터가 있을지 확인 해주시면 감사하겠습니다.

close #10