### PR TITLE
유저 프로필 조회 API 차단된 유저 구분 응답 필드 추가

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -601,8 +601,15 @@ paths:
                             type: integer
                             description: 받은 좋아요 수
                             example: 1
+                          isBlocked:
+                            type: boolean
+                            description: 차단 여부 (아직 적용 및 배포되지 않았습니다!)
+                            example: false
                           posts:
                             type: array
+                            description: |-
+                              유저가 작성한 게시글
+                              - 차단된 경우는 빈 배열로 응답합니다.
                             items:
                               type: object
                               properties:
@@ -641,6 +648,7 @@ paths:
                           - profileImageUrl
                           - postCount
                           - thumbsUpCount
+                          - isBlocked
                           - posts
                     required:
                       - user


### PR DESCRIPTION
<img width="263" alt="image" src="https://github.com/team-ppeople/pp-oas-swagger/assets/52724515/5d3ae0e8-cee6-4fc4-a6c2-950caa0c5644">

유저 프로필 조회 API 응답 필드로 유저가 차단된 여부를 구분할 수 있는 응답 필드(`isBlocked`)를 추가했습니다.
차단된 경우는 유저의 게시글이 빈 배열 형태로 조회되도록 적용할 예정입니다.
검토해보시고 의견 있으시면 말씀해주세요~